### PR TITLE
feat: allow setting RDF arrays

### DIFF
--- a/src/__tests__/__snapshots__/decorator-property.spec.ts.snap
+++ b/src/__tests__/__snapshots__/decorator-property.spec.ts.snap
@@ -31,9 +31,16 @@ exports[`decorator term setter can set array 1`] = `
 
 exports[`decorator term setter can set empty array, removing objects 1`] = `""`;
 
+exports[`decorator term setter sets nil for empty rdf list 1`] = `
+"<http://example.com/res> <http://xmlns.com/foaf/0.1/knows> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+"
+`;
+
 exports[`decorator term setter sets value at paths of arbitrary length 1`] = `
 "<http://example.com/factory> <http://xmlns.com/foaf/0.1/name> \\"Google\\" .
 <http://example.com/friend> <http://example.com/worksAt> <http://example.com/factory> .
 <http://example.com/res> <http://xmlns.com/foaf/0.1/friend> <http://example.com/friend> .
 "
 `;
+
+exports[`decorator term setter setting null to rdf list removes triple 1`] = `""`;

--- a/src/__tests__/__snapshots__/decorator-resource.spec.ts.snap
+++ b/src/__tests__/__snapshots__/decorator-resource.spec.ts.snap
@@ -29,6 +29,21 @@ exports[`decorator resource setter sets a relation between resources 1`] = `
 "
 `;
 
+exports[`decorator resource setter sets array to rdf list property 1`] = `
+"<http://example.com/john> <http://xmlns.com/foaf/0.1/knows> _:c14n1 .
+_:c14n0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://example.com/joe> .
+_:c14n0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:c14n1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://example.com/jane> .
+_:c14n1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n0 .
+"
+`;
+
+exports[`decorator resource setter sets array to set property 1`] = `
+"<http://example.com/john> <http://xmlns.com/foaf/0.1/knows> <http://example.com/jane> .
+<http://example.com/john> <http://xmlns.com/foaf/0.1/knows> <http://example.com/joe> .
+"
+`;
+
 exports[`decorator resource setter setting null removes relation 1`] = `
 "<http://example.com/jane> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Person> .
 <http://example.com/john> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Person> .

--- a/src/__tests__/decorator-literal.spec.ts
+++ b/src/__tests__/decorator-literal.spec.ts
@@ -120,7 +120,7 @@ describe('decorator', () => {
           ex:res ex:letters ( "a" "b" "c" ) .
         `)
         class Resource extends RdfResource {
-          @property.literal({ path: ex.letters, array: true })
+          @property.literal({ path: ex.letters, values: 'list' })
           letters?: string[]
         }
 

--- a/src/__tests__/decorator-resource.spec.ts
+++ b/src/__tests__/decorator-resource.spec.ts
@@ -73,7 +73,7 @@ describe('decorator', () => {
           ex:res foaf:knows ( ex:Will ex:Joe ex:Sindy ) .
         `)
         class Resource extends RdfResource {
-          @property.resource({ path: foaf.knows, array: true })
+          @property.resource({ path: foaf.knows, values: 'list' })
           friends!: RdfResource[]
         }
 
@@ -160,6 +160,59 @@ describe('decorator', () => {
 
         // when
         john.spouse = ex.jane
+
+        // then
+        expect(dataset.toCanonical()).toMatchSnapshot()
+      })
+
+      it('sets array to rdf list property', async () => {
+        // given
+        const dataset = await parse(`
+          @prefix ex: <${prefixes.ex}> .
+          @prefix foaf: <${prefixes.foaf}> .
+          
+          ex:john foaf:knows (
+            ex:stacy
+            ex:frank
+          ) .
+        `)
+
+        class Resource extends RdfResource {
+          @property.resource({ path: foaf.knows, values: 'list' })
+          knows?: (RdfResource | NamedNode)[]
+        }
+        const john = new Resource({ dataset, term: ex.john })
+
+        // when
+        john.knows = [
+          ex.jane,
+          ex.joe,
+        ]
+
+        // then
+        expect(dataset.toCanonical()).toMatchSnapshot()
+      })
+
+      it('sets array to set property', async () => {
+        // given
+        const dataset = await parse(`
+          @prefix ex: <${prefixes.ex}> .
+          @prefix foaf: <${prefixes.foaf}> .
+          
+          ex:john foaf:knows ex:stacy, ex:frank .
+        `)
+
+        class Resource extends RdfResource {
+          @property.resource({ path: foaf.knows, values: 'array' })
+          knows?: (RdfResource | NamedNode)[]
+        }
+        const john = new Resource({ dataset, term: ex.john })
+
+        // when
+        john.knows = [
+          ex.jane,
+          ex.joe,
+        ]
 
         // then
         expect(dataset.toCanonical()).toMatchSnapshot()

--- a/src/example/resources.ts
+++ b/src/example/resources.ts
@@ -11,7 +11,7 @@ export interface Collection extends RdfResource {
 export function CollectionMixin<Base extends Constructor>(base: Base) {
   @namespace(hydra)
   class C extends base implements Collection {
-    @property.resource({ path: 'member', array: true })
+    @property.resource({ path: 'member', values: 'array' })
     members!: HydraResource[]
   }
 

--- a/src/lib/decorators/property/literal.ts
+++ b/src/lib/decorators/property/literal.ts
@@ -1,0 +1,41 @@
+import { RdfResource } from '../../RdfResource'
+import { Literal, NamedNode } from 'rdf-js'
+import { fromLiteral } from '../../conversion'
+import { xsd } from '../../vocabs'
+import rdf from 'rdf-data-model'
+import { AccessorOptions, ObjectOrFactory, propertyDecorator } from '../property'
+
+interface LiteralOptions<R extends RdfResource> {
+  type?: typeof Boolean | typeof String | typeof Number
+  initial?: ObjectOrFactory<R, string | boolean | number | bigint | Literal>
+}
+
+const trueLiteral: Literal = rdf.literal('true', xsd.boolean)
+
+export default function<R extends RdfResource> (options: AccessorOptions & LiteralOptions<R> = {}) {
+  const type = options.type || String
+
+  return propertyDecorator<unknown, Literal>({
+    ...options,
+    fromTerm(obj) {
+      return fromLiteral(type, obj)
+    },
+    toTerm(value: any) {
+      let datatype: NamedNode | undefined
+      if (type === Boolean) {
+        datatype = trueLiteral.datatype
+      }
+      if (type === Number && Number.isInteger(value)) {
+        datatype = xsd.integer
+      } else if (type === Number) {
+        datatype = xsd.float
+      }
+
+      return rdf.literal(value.toString(), datatype)
+    },
+    valueTypeName: type.name,
+    assertSetValue: (value: any) => {
+      return typeof value !== 'object' || value.termType === 'Literal'
+    },
+  })
+}

--- a/src/lib/decorators/property/resource.ts
+++ b/src/lib/decorators/property/resource.ts
@@ -1,0 +1,32 @@
+import { RdfResource } from '../../RdfResource'
+import { BlankNode, NamedNode } from 'rdf-js'
+import { fromResource } from '../../conversion'
+import { AccessorOptions, ObjectOrFactory, propertyDecorator } from '../property'
+import { Constructor, Mixin } from '../../ResourceFactory'
+
+interface ResourceOptions<R extends RdfResource> {
+  as?: Mixin<any>[] | [Constructor, ...Mixin<any>[]]
+  initial?: ObjectOrFactory<R, BlankNode | NamedNode | RdfResource>
+}
+
+function resourcePropertyDecorator<R extends RdfResource>(options: AccessorOptions & ResourceOptions<R> = {}) {
+  return propertyDecorator<RdfResource, BlankNode | NamedNode>({
+    ...options,
+    fromTerm(this: RdfResource, obj) {
+      return fromResource(this, obj as any, options.as)
+    },
+    toTerm(value: RdfResource) {
+      return value.id
+    },
+    valueTypeName: 'RdfResource instance',
+    assertSetValue: (value) => {
+      if ('termType' in value) {
+        return value.termType === 'NamedNode' || value.termType === 'BlankNode'
+      }
+
+      return true
+    },
+  })
+}
+
+export default resourcePropertyDecorator


### PR DESCRIPTION
BREAKING CHANGE: decorator's `array: boolean` changed to `values: 'array' | 'list' | undefined`