### PR TITLE
Init nested resource using strong interface

### DIFF
--- a/.changeset/forty-flowers-tell.md
+++ b/.changeset/forty-flowers-tell.md
@@ -1,0 +1,5 @@
+---
+"@tpluscode/rdfine": patch
+---
+
+Types initialied with TypeCollection are not added

--- a/.changeset/hot-bugs-glow.md
+++ b/.changeset/hot-bugs-glow.md
@@ -1,0 +1,5 @@
+---
+"@tpluscode/rdfine": patch
+---
+
+Initializing nested resources using typed interface

--- a/packages/core/RdfResource.ts
+++ b/packages/core/RdfResource.ts
@@ -127,8 +127,8 @@ export default class RdfResourceImpl<D extends DatasetCore = DatasetCore> implem
         resource.pointer.addOut(resource.pointer.namedNode(prop), pointers)
       })
 
-    if (init.types && Array.isArray(init.types)) {
-      init.types.forEach(type => resource.types.add(type))
+    for (const type of init.types || []) {
+      resource.types.add(type)
     }
   }
 

--- a/packages/core/__tests__/ResourceFactory.spec.ts
+++ b/packages/core/__tests__/ResourceFactory.spec.ts
@@ -1,10 +1,11 @@
 import cf from 'clownface'
-import { foaf, schema } from '@tpluscode/rdf-ns-builders'
+import { foaf, rdf, schema } from '@tpluscode/rdf-ns-builders'
 import { turtle } from '@tpluscode/rdf-string'
 import $rdf from 'rdf-ext'
 import ResourceFactory, { Constructor } from '../lib/ResourceFactory'
 import { parse, ex } from './_helpers'
 import RdfResourceImpl from '../RdfResource'
+import clownface from 'clownface'
 
 function NeverApply() {
   return class {
@@ -107,5 +108,21 @@ describe('ResourceFactory', () => {
 
     // then
     expect(entity.bar).toBe('baz')
+  })
+
+  it('sets rdf:types initialized with TypeCollection', () => {
+    // given
+    const pointer = clownface({ dataset: $rdf.dataset() }).blankNode()
+    const { types } = new RdfResourceImpl(clownface({ dataset: $rdf.dataset() }).blankNode().addOut(rdf.type, schema.Person))
+
+    // when
+    const resource = factory.createEntity(pointer, [], {
+      initializer: {
+        types,
+      },
+    })
+
+    // then
+    expect(resource.types.has(schema.Person)).toBe(true)
   })
 })

--- a/packages/core/lib/ResourceFactory.ts
+++ b/packages/core/lib/ResourceFactory.ts
@@ -84,7 +84,16 @@ export default class <D extends DatasetCore = DatasetCore, R extends RdfResource
       }
     }
 
-    BaseClass = this.__getBaseClass(BaseClass, pointer.out(rdf.type).values)
+    const types = pointer.out(rdf.type).values
+    for (const type of options.initializer?.types || []) {
+      if ('termType' in type) {
+        types.push(type.value)
+      } else {
+        types.push(type.id.value)
+      }
+    }
+
+    BaseClass = this.__getBaseClass(BaseClass, types)
     const entity = new BaseClass(pointer)
 
     const mixins = [...this.__mixins].reduce<Set<Mixin<T>>>((selected, next) => {
@@ -96,6 +105,7 @@ export default class <D extends DatasetCore = DatasetCore, R extends RdfResource
     }, new Set(explicitMixins))
 
     const Type = this.__extend(BaseClass, [...mixins])
+    Type.factory = this
 
     return createProxy(new Type(pointer, options.initializer, options.parent)) as R & S & ResourceIndexer<R>
   }


### PR DESCRIPTION
This fixes a scenario where a child resource is initialised using a strongly typed interface implemented by a known mixin class.

For example, a SHACL property shape with a child Hydra IriTemplate

```typescript
import * as PropertyShape from '@rdfine/shacl/lib/PropertyShape'

const propertyShape = PropertyShape.fromPointer(node, {
    [hydra.search.value]: {
      types: [hydra.IriTemplate],
      template: 'collection{?search}',
    },
  })
```

The use of `types` should be enough to find the right property name for the `template` property (`hydra:template`)