### PR TITLE
fix: remove member property from RdfsResource

### DIFF
--- a/.changeset/quiet-bears-draw.md
+++ b/.changeset/quiet-bears-draw.md
@@ -1,0 +1,5 @@
+---
+"@rdfine/rdfs": patch
+---
+
+Remove rdfs:member

--- a/vocabularies/rdfs/lib/Resource.ts
+++ b/vocabularies/rdfs/lib/Resource.ts
@@ -11,7 +11,6 @@ export interface Resource<D extends RDF.DatasetCore = RDF.DatasetCore> extends R
   comment: string | undefined;
   isDefinedBy: Rdfs.Resource<D> | undefined;
   label: string | undefined;
-  member: Array<Rdfs.Resource<D>>;
   seeAlso: Array<Rdfs.Resource<D>>;
 }
 
@@ -24,8 +23,6 @@ export function ResourceMixin<Base extends Constructor>(Resource: Base): Constru
     isDefinedBy: Rdfs.Resource | undefined;
     @property.literal()
     label: string | undefined;
-    @property.resource({ values: 'array', as: [ResourceMixin] })
-    member!: Array<Rdfs.Resource>;
     @property.resource({ values: 'array', as: [ResourceMixin] })
     seeAlso!: Array<Rdfs.Resource>;
   }

--- a/vocabularies/rdfs/package.json
+++ b/vocabularies/rdfs/package.json
@@ -37,10 +37,10 @@
     "types": {
       "Literal": "string"
     },
+    "exclude": [
+      "member"
+    ],
     "properties": {
-      "member": {
-        "values": "array"
-      },
       "seeAlso": {
         "values": "array"
       },


### PR DESCRIPTION
This is not a fix for #128 but at least alleviates the problem with Hydra Collections.

Technically this should be a breaking change but the `rdfs:member` property itself is so useless that I think it justifies a patch version