### PR TITLE
feat: removed apiDocumentation

### DIFF
--- a/.changeset/green-maps-joke.md
+++ b/.changeset/green-maps-joke.md
@@ -1,0 +1,5 @@
+---
+"@rdfine/hydra": minor
+---
+
+Removed generated property getter `hydra:apiDocumentation`

--- a/vocabularies/hydra/bundles/Resource.ts
+++ b/vocabularies/hydra/bundles/Resource.ts
@@ -1,12 +1,10 @@
 import type { Mixin } from '@tpluscode/rdfine/lib/ResourceFactory';
-import { ApiDocumentationMixin } from '../lib/ApiDocumentation';
 import { CollectionMixin } from '../lib/Collection';
 import { ResourceMixin } from '../lib/Resource';
 import { OperationMixin } from '../lib/Operation';
 import { IriTemplateMixin } from '../lib/IriTemplate';
 
 export const ResourceBundle = [
-  ApiDocumentationMixin as Mixin,
   CollectionMixin as Mixin,
   ResourceMixin as Mixin,
   OperationMixin as Mixin,

--- a/vocabularies/hydra/lib/Resource.ts
+++ b/vocabularies/hydra/lib/Resource.ts
@@ -10,7 +10,6 @@ import type * as Rdfs from '@rdfine/rdfs';
 import { ResourceMixin as RdfsResourceMixin } from '@rdfine/rdfs/lib/Resource';
 
 export interface Resource<D extends RDF.DatasetCore = RDF.DatasetCore> extends Rdfs.Resource<D>, RdfResource<D> {
-  apiDocumentation: Hydra.ApiDocumentation<D> | undefined;
   collection: Array<Hydra.Collection<Hydra.Resource<D>, D>>;
   first: Hydra.Resource<D> | undefined;
   freetextQuery: string | undefined;
@@ -25,8 +24,6 @@ export interface Resource<D extends RDF.DatasetCore = RDF.DatasetCore> extends R
 export function ResourceMixin<Base extends Constructor>(Resource: Base): Constructor<Partial<Resource> & RdfResourceCore> & Base {
   @namespace(hydra)
   class ResourceClass extends RdfsResourceMixin(Resource) implements Partial<Resource> {
-    @property.resource({ implicitTypes: [hydra.ApiDocumentation] })
-    apiDocumentation: Hydra.ApiDocumentation | undefined;
     @property.resource({ values: 'array', implicitTypes: [hydra.Collection] })
     collection!: Array<Hydra.Collection<any, any>>;
     @property.resource({ as: [ResourceMixin] })

--- a/vocabularies/hydra/package.json
+++ b/vocabularies/hydra/package.json
@@ -37,6 +37,9 @@
     "types": {
       "BaseUriSource": "NamedNode"
     },
+    "exclude": [
+      "apiDocumentation"
+    ],
     "properties": {
       "collection": {
         "values": "array"


### PR DESCRIPTION
This removes the property getter for `hydra:apiDocumentation` because I figured it did not make sense for the property which is mostly intended for the HTTP Link header

If necessary, it's always possible to access by the predicate name

```diff
import { hydra } from '@tpluscode/rdf-ns-builders'
import { ApiDocumentation } from '@rdfine/hydra'

-const apiDoc = res.apiDocumentation
+const apiDoc = res.get<ApiDocumentation>(hydra.apiDocumentation)